### PR TITLE
Update events.md

### DIFF
--- a/docs/content/api/events.md
+++ b/docs/content/api/events.md
@@ -34,13 +34,13 @@
 
 - **Arguments:** `editor: Ref<Element>`
 
-  Triggered when the editor loses focus.
+  Triggered when the editor gains focus.
 
 ## @blur
 
 - **Arguments:** `editor: Ref<Element>`
   
-  Triggered when the editor gains focus.
+  Triggered when the editor loses focus.
 
 ## @ready
 


### PR DESCRIPTION
Fixed blur and focus typo, descriptions are now correct.

`@blur` & `@focus` descriptions were originally the wrong way around.