### PR TITLE
Proper setContents method for html content

### DIFF
--- a/packages/vue-quill/src/components/QuillEditor.ts
+++ b/packages/vue-quill/src/components/QuillEditor.ts
@@ -318,7 +318,7 @@ export const QuillEditor = defineComponent({
           : ''
         : content
       if (props.contentType === 'html') {
-        setHTML(normalizedContent as string)
+        pasteHTML(normalizedContent as string)
       } else if (props.contentType === 'text') {
         setText(normalizedContent as string, source)
       } else {


### PR DESCRIPTION
If there is space in between HTML tags, lists weren't rendered properly.

Using the pasteHTML method instead of setHTML was handling these kinds of cases properly.
Fixes: https://github.com/vueup/vue-quill/issues/379
