### PR TITLE
fix: merge module options correctly

### DIFF
--- a/packages/vue-quill/src/components/QuillEditor.ts
+++ b/packages/vue-quill/src/components/QuillEditor.ts
@@ -186,6 +186,9 @@ export const QuillEditor = defineComponent({
           modules
         )
       }
+      if (props.options?.modules) {
+        clientOptions.modules = Object.assign({}, clientOptions.modules, props.options.modules)
+      }
       return Object.assign(
         {},
         props.globalOptions,


### PR DESCRIPTION
Fixing issue https://github.com/vueup/vue-quill/issues/392

To enable globally registered modules we have to be careful not to overwrite the module options. 
This happens currently in the Object.assign when options are merged.
More rationale in the issue