### PR TITLE
Update the editor upon receiving an empty html string

### DIFF
--- a/packages/vue-quill/src/components/QuillEditor.ts
+++ b/packages/vue-quill/src/components/QuillEditor.ts
@@ -363,7 +363,12 @@ export const QuillEditor = defineComponent({
     watch(
       () => props.content,
       (newContent) => {
-        if (!quill || !newContent || internalModelEquals(newContent)) return
+        if (
+          quill == null ||
+          newContent == null ||
+          internalModelEquals(newContent)
+        )
+          return
 
         // Restore the selection and cursor position after updating the content
         const selection = quill.getSelection()


### PR DESCRIPTION
Hello,

I have discovered the following issue: when using `content-type="html"`, the editor does not re-render when it receives an empty string via the `content` prop. E.g. imagine appending the following code to `demo/src/examples/ContentType.vue`'s template:

```html
<button
  type="button"
  @click="contentHTML = ''"
>
  clear
</button>
```

I would assume that an empty string is a valid HTML snippet representing an empty document; therefore, I would expect that clicking the button would clear the editor. However, nothing happens.

The cause of this behavior is the initial guard clause in the `content` prop watcher's callback in `QuillEdtor.vue`. When **any** [falsy](https://developer.mozilla.org/en-US/docs/Glossary/Falsy) value -- including an empty string -- is received in the `content` prop, the callback returns early without calling the `setContents` function.

To solve the issue, I propose checking whether the received value is [nullish](https://developer.mozilla.org/en-US/docs/Glossary/Nullish) rather than falsy. This will only change the behavior for empty strings, leaving everything else intact, and thus not introduce other breaking changes to the API. **The single submitted commit implements this proposal.**

---

P.S. In my opinion, even nullish values should not be simply ignored, as it breaks the component's reactivity -- it may display historical data. Perhaps they should be somehow normalized, e.g. replaced with an "empty delta" / empty HTML string, leading to the editor's re-render. However, this is out of the scope of the discussed issue.