### PR TITLE
fix: xss

### DIFF
--- a/packages/vue-quill/src/components/QuillEditor.ts
+++ b/packages/vue-quill/src/components/QuillEditor.ts
@@ -340,7 +340,7 @@ export const QuillEditor = defineComponent({
     }
 
     const setHTML = (html: string) => {
-      if (quill) quill.root.innerHTML = html
+      if (quill) pasteHTML(html)
     }
 
     const pasteHTML = (html: string, source: Sources = 'api') => {


### PR DESCRIPTION
Exploit:

```
<QuillEditor content="<img src=x onerror='alert()'/>" contentType="html"/>
```

![image](https://github.com/vueup/vue-quill/assets/57182600/c4f25a3e-c1f1-419c-b15f-865295ccc3c1)
