### PR TITLE
chore: update examples to vue-quill 1.4.0

### DIFF
--- a/examples/nuxt-app/package-lock.json
+++ b/examples/nuxt-app/package-lock.json
@@ -7,7 +7,7 @@
       "name": "vue-quill-nuxt-example",
       "hasInstallScript": true,
       "dependencies": {
-        "@vueup/vue-quill": "^1.3.0",
+        "@vueup/vue-quill": "^1.4.0",
         "nuxt": "^4.4.6",
         "vue": "^3.5.34",
         "vue-router": "^5.0.7"
@@ -4715,9 +4715,9 @@
       "license": "MIT"
     },
     "node_modules/@vueup/vue-quill": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@vueup/vue-quill/-/vue-quill-1.3.0.tgz",
-      "integrity": "sha512-GzliVRz+K51pmhZhA2LLg3W1Vj4a05oBeu+L7utz/S857yyIc7CEMoE1N+FNoHBcCO4/n61Z8vRrKtFVy0oNYg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@vueup/vue-quill/-/vue-quill-1.4.0.tgz",
+      "integrity": "sha512-bZi/i8u5mYANieK5GU1ECKXqaoozkFhhR6wk4C3ZKQ5jm36FynKT37P1ZK2CfIkb9CLdDnLfkyWc6aUECsSLKQ==",
       "license": "MIT",
       "dependencies": {
         "quill": "2.0.2 || >=2.0.4 <3",
@@ -5465,16 +5465,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
-    },
-    "node_modules/commander": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
-      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
-      "extraneous": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
     },
     "node_modules/commondir": {
       "version": "1.0.1",

--- a/examples/nuxt-app/package.json
+++ b/examples/nuxt-app/package.json
@@ -18,7 +18,7 @@
     "typecheck": "nuxt typecheck"
   },
   "dependencies": {
-    "@vueup/vue-quill": "^1.3.0",
+    "@vueup/vue-quill": "^1.4.0",
     "nuxt": "^4.4.6",
     "vue": "^3.5.34",
     "vue-router": "^5.0.7"

--- a/examples/vite-app/package-lock.json
+++ b/examples/vite-app/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@vue/server-renderer": "^3.5.35",
-        "@vueup/vue-quill": "^1.3.0",
+        "@vueup/vue-quill": "^1.4.0",
         "express": "^5.2.1",
         "vue": "^3.5.35"
       },
@@ -622,9 +622,9 @@
       }
     },
     "node_modules/@vueup/vue-quill": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@vueup/vue-quill/-/vue-quill-1.3.0.tgz",
-      "integrity": "sha512-GzliVRz+K51pmhZhA2LLg3W1Vj4a05oBeu+L7utz/S857yyIc7CEMoE1N+FNoHBcCO4/n61Z8vRrKtFVy0oNYg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@vueup/vue-quill/-/vue-quill-1.4.0.tgz",
+      "integrity": "sha512-bZi/i8u5mYANieK5GU1ECKXqaoozkFhhR6wk4C3ZKQ5jm36FynKT37P1ZK2CfIkb9CLdDnLfkyWc6aUECsSLKQ==",
       "license": "MIT",
       "dependencies": {
         "quill": "2.0.2 || >=2.0.4 <3",

--- a/examples/vite-app/package.json
+++ b/examples/vite-app/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@vue/server-renderer": "^3.5.35",
-    "@vueup/vue-quill": "^1.3.0",
+    "@vueup/vue-quill": "^1.4.0",
     "express": "^5.2.1",
     "vue": "^3.5.35"
   },


### PR DESCRIPTION
## Summary

- Update Vite and Nuxt example dependencies to `@vueup/vue-quill@^1.4.0`
- Refresh both example lockfiles so npm-mode installs use the newly published SSR-safe package

## Validation

- `npm ci` in `examples/vite-app`
- `npm ci` in `examples/nuxt-app`
- `npm run build:ssr:npm` in `examples/vite-app`
- `node scripts/smoke-ssr.mjs` in `examples/vite-app`
- `npm run build:npm` in `examples/nuxt-app`
- `npm run generate:npm && node scripts/smoke-generate.mjs` in `examples/nuxt-app`
