### PR TITLE
ci: deploy Vite SSR example to GitHub Pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,9 @@ jobs:
       - name: Test Vite SSR example
         working-directory: examples/vite-app
         run: npm run test:ssr
+      - name: Test Vite SSR Pages example
+        working-directory: examples/vite-app
+        run: npm run test:ssr:pages
       - name: Test Nuxt example rendering
         working-directory: examples/nuxt-app
         run: npm run test:rendering

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -64,6 +64,13 @@ jobs:
         run: |
           mkdir -p docs/content/.vitepress/dist/examples/vite-app
           cp -R examples/vite-app/dist/. docs/content/.vitepress/dist/examples/vite-app/
+      - name: Build Vite SSR example for GitHub Pages
+        working-directory: examples/vite-app
+        run: npm run test:ssr:pages
+      - name: Add Vite SSR example to docs deploy
+        run: |
+          mkdir -p docs/content/.vitepress/dist/examples/vite-app/ssr
+          cp -R examples/vite-app/dist/client/. docs/content/.vitepress/dist/examples/vite-app/ssr/
       - name: Build Nuxt example for GitHub Pages
         working-directory: examples/nuxt-app
         run: npm run test:pages

--- a/docs/content/.vitepress/config.mts
+++ b/docs/content/.vitepress/config.mts
@@ -5,6 +5,10 @@ const ogDescription = 'VueQuill Rich Text Editor for Vue 3'
 const ogImage = 'https://vueup.github.io/vue-quill/og-image.png'
 const ogTitle = 'VueQuill'
 const ogUrl = 'https://vueup.github.io/vue-quill/'
+const viteExampleUrl = 'https://vueup.github.io/vue-quill/examples/vite-app/'
+const viteSsrExampleUrl =
+  'https://vueup.github.io/vue-quill/examples/vite-app/ssr/'
+const nuxtExampleUrl = 'https://vueup.github.io/vue-quill/examples/nuxt-app/'
 
 export default defineConfig({
   base: '/vue-quill/',
@@ -58,6 +62,29 @@ export default defineConfig({
     nav: [
       { text: 'Guide', link: '/guide/' },
       { text: 'API Reference', link: '/api/' },
+      {
+        text: 'Examples',
+        items: [
+          {
+            text: 'Vite example',
+            link: viteExampleUrl,
+            target: '_blank',
+            rel: 'noopener noreferrer',
+          },
+          {
+            text: 'Vite SSR example',
+            link: viteSsrExampleUrl,
+            target: '_blank',
+            rel: 'noopener noreferrer',
+          },
+          {
+            text: 'Nuxt example',
+            link: nuxtExampleUrl,
+            target: '_blank',
+            rel: 'noopener noreferrer',
+          },
+        ],
+      },
       {
         text: 'Support VueQuill',
         items: [

--- a/docs/content/.vitepress/theme/components/HomeDemo.vue
+++ b/docs/content/.vitepress/theme/components/HomeDemo.vue
@@ -1,5 +1,20 @@
 <script setup lang="ts">
 import DemoEditor from './demo/DemoEditor.vue'
+
+const exampleLinks = [
+  {
+    label: 'Open Vite example',
+    href: 'https://vueup.github.io/vue-quill/examples/vite-app/',
+  },
+  {
+    label: 'Open Vite SSR example',
+    href: 'https://vueup.github.io/vue-quill/examples/vite-app/ssr/',
+  },
+  {
+    label: 'Open Nuxt example',
+    href: 'https://vueup.github.io/vue-quill/examples/nuxt-app/',
+  },
+]
 </script>
 
 <template>
@@ -8,14 +23,29 @@ import DemoEditor from './demo/DemoEditor.vue'
       <div class="container">
         <div class="block py-4">
           <header class="text-center pb-5">
-            <h2 id="demo" class="font-semibold border-none mb-2">Interactive Demo</h2>
+            <h2 id="demo" class="font-semibold border-none mb-2">
+              Interactive Demo
+            </h2>
             <p class="mx-auto max-w-lg my-2">
-              What you see is what you get. Try out our interactive demo and discover all the features packed into VueQuill.
+              What you see is what you get. Try out our interactive demo and
+              discover all the features packed into VueQuill.
             </p>
           </header>
           <ClientOnly>
             <DemoEditor></DemoEditor>
           </ClientOnly>
+          <div class="demo-links" aria-label="Full example applications">
+            <a
+              v-for="link in exampleLinks"
+              :key="link.href"
+              class="demo-link"
+              :href="link.href"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {{ link.label }}
+            </a>
+          </div>
         </div>
       </div>
     </div>
@@ -25,13 +55,46 @@ import DemoEditor from './demo/DemoEditor.vue'
 <style scoped>
 .VPHomeDemo {
   margin-top: 112px;
-    margin-bottom: -128px;
-    border-top: 1px solid var(--vp-c-divider-light);
-    padding: 88px 24px 96px;
-    background-color: var(--vp-c-bg);
+  margin-bottom: -128px;
+  border-top: 1px solid var(--vp-c-divider-light);
+  padding: 88px 24px 96px;
+  background-color: var(--vp-c-bg);
 }
 .container {
   margin: 0 auto;
   max-width: 1152px;
+}
+
+.demo-links {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 12px;
+  margin-top: 32px;
+}
+
+.demo-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 40px;
+  padding: 0 18px;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 6px;
+  color: var(--vp-c-brand);
+  font-weight: 600;
+  text-decoration: none;
+  transition:
+    border-color 0.2s,
+    color 0.2s;
+}
+
+.demo-link:hover {
+  border-color: var(--vp-c-brand);
+  color: var(--vp-c-brand-dark);
+}
+
+.dark .demo-link:hover {
+  color: var(--vp-c-brand-lightest);
 }
 </style>

--- a/examples/vite-app/README.md
+++ b/examples/vite-app/README.md
@@ -11,6 +11,7 @@ browser.
 - `npm run dev` and `npm run dev:ssr` use the local workspace source from `../../packages/vue-quill` when that package is available.
 - `npm run dev:npm` forces the released npm package, which is useful for comparison.
 - `npm run build` and `npm run build:pages` do not apply the local alias, so production SPA builds resolve `@vueup/vue-quill` from npm.
+- `npm run build:ssr:pages` builds a static, prerendered SSR page for GitHub Pages using the released npm package.
 - `npm run test:ssr` and `npm run build:ssr` intentionally use the local workspace source through Vite's `workspace-ssr` and `workspace` modes so CI can verify unreleased SSR changes.
 - `npm run build:ssr:npm` forces the released npm package for comparison after an SSR-capable release is published.
 
@@ -19,6 +20,10 @@ The source for the example lives in `../vue-quill/src` and is imported through t
 When deployed with the docs site, the example is published at:
 
 https://vueup.github.io/vue-quill/examples/vite-app/
+
+The Pages-compatible static SSR build is published at:
+
+https://vueup.github.io/vue-quill/examples/vite-app/ssr/
 
 ## Commands
 
@@ -31,6 +36,8 @@ npm run dev:ssr
 npm run build
 npm run build:ssr
 npm run build:pages
+npm run build:ssr:pages
+npm run test:ssr:pages
 npm run preview
 npm run preview:ssr
 ```

--- a/examples/vite-app/package.json
+++ b/examples/vite-app/package.json
@@ -12,13 +12,15 @@
     "build:pages": "vue-tsc -b && vite build --base=/vue-quill/examples/vite-app/",
     "build:ssr": "npm run build:ssr:workspace",
     "build:ssr:client": "vite build --outDir dist/client",
+    "build:ssr:pages": "vue-tsc -b && npm run build:ssr:client -- --mode npm-ssr --base=/vue-quill/examples/vite-app/ssr/ && npm run build:ssr:server -- --mode npm && node scripts/prerender-ssr.mjs",
     "build:ssr:workspace": "npm run build:ssr:client -- --mode workspace-ssr && npm run build:ssr:server -- --mode workspace",
     "build:ssr:npm": "npm run build:ssr:client -- --mode npm-ssr && npm run build:ssr:server -- --mode npm",
     "build:ssr:server": "vite build --ssr src/entry-server.ts --outDir dist/server",
     "preview": "vite preview",
     "preview:ssr": "NODE_ENV=production node server.mjs",
     "test": "node --experimental-strip-types --test ../vue-quill/src/example-catalog.test.ts",
-    "test:ssr": "vue-tsc -b && npm run build:ssr:workspace && node scripts/smoke-ssr.mjs"
+    "test:ssr": "vue-tsc -b && npm run build:ssr:workspace && node scripts/smoke-ssr.mjs",
+    "test:ssr:pages": "npm run build:ssr:pages && node scripts/smoke-ssr-pages.mjs"
   },
   "dependencies": {
     "@vue/server-renderer": "^3.5.35",

--- a/examples/vite-app/scripts/prerender-ssr.mjs
+++ b/examples/vite-app/scripts/prerender-ssr.mjs
@@ -1,0 +1,23 @@
+import { readFile, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const clientDir = path.join(rootDir, 'dist/client')
+const templatePath = path.join(clientDir, 'index.ssr.html')
+const outputPath = path.join(clientDir, 'index.html')
+const serverEntryUrl = pathToFileURL(
+  path.join(rootDir, 'dist/server/entry-server.js'),
+)
+
+const template = await readFile(templatePath, 'utf8')
+const { render } = await import(serverEntryUrl.href)
+const appHtml = await render()
+
+if (!template.includes('<!--app-html-->')) {
+  throw new Error('SSR template is missing the app HTML placeholder.')
+}
+
+await writeFile(outputPath, template.replace('<!--app-html-->', appHtml))
+
+console.log(`Vite SSR static HTML written to ${outputPath}.`)

--- a/examples/vite-app/scripts/smoke-ssr-pages.mjs
+++ b/examples/vite-app/scripts/smoke-ssr-pages.mjs
@@ -1,0 +1,18 @@
+import { readFile } from 'node:fs/promises'
+
+const html = await readFile('dist/client/index.html', 'utf8')
+
+const expectedSnippets = [
+  'Vue Quill Vite SSR Example',
+  'Comprehensive Vue Quill examples',
+  'Basic editor',
+  '/vue-quill/examples/vite-app/ssr/assets/',
+]
+
+for (const snippet of expectedSnippets) {
+  if (!html.includes(snippet)) {
+    throw new Error(`Vite SSR Pages HTML did not include "${snippet}".`)
+  }
+}
+
+console.log('Vite SSR Pages smoke passed.')


### PR DESCRIPTION
## Summary

- Add an `Examples` docs nav dropdown that opens the Vite, Vite SSR, and Nuxt example apps in new tabs
- Add the same full-example links under the homepage Interactive Demo
- Add a Vite SSR GitHub Pages build that prerenders the SSR shell to static HTML at `/examples/vite-app/ssr/`
- Wire the Vite SSR Pages build into CI and the docs deployment workflow

## Notes

GitHub Pages cannot run the local Node SSR server, so the deployed Vite SSR target is a static prerendered SSR page with client hydration.

## Validation

- `npm run test:ssr:pages` in `examples/vite-app`
- `npm run docs:build`
- Generated docs HTML smoke for the Vite, Vite SSR, and Nuxt links
- Copied Vite SSR Pages output smoke under `docs/content/.vitepress/dist/examples/vite-app/ssr/`
- Local browser smoke at `http://localhost:4173/vue-quill/examples/vite-app/ssr/`: 8 editors, 7 toolbars, correct asset base path, no console warnings/errors
