### PR TITLE
[codex] fix: support disabling toolbar prop

### DIFF
--- a/docs/content/api/index.md
+++ b/docs/content/api/index.md
@@ -51,9 +51,9 @@
   The name of the theme to apply to the editor, Quill features two officially supported themes: `snow` and `bubble`. Pass `""` to use the minimal core theme. See the [docs on themes](https://quilljs.com/docs/themes/) for more information on including the required stylesheets. 
 
 ## toolbar
-- **Type:** `String | Array | Object`
+- **Type:** `String | Array | Object | false`
 
-  Toolbar options to configure the default toolbar icons using an array of format names, see [Toolbar](../guide/toolbar.md) section for more details.
+  Toolbar options to configure the default toolbar icons using an array of format names. Pass `false` to disable the toolbar. See [Toolbar](../guide/toolbar.md) section for more details.
 
 ## modules
 - **Type:** `Object | Object[]`

--- a/docs/content/guide/toolbar.md
+++ b/docs/content/guide/toolbar.md
@@ -1,7 +1,7 @@
 # Toolbar
 The toolbar module allows users to easily format Quill’s contents. It can be configured with a  [`toolbar` prop](../api/index.md#toolbar).
 
-There are 3 ways to configure the toolbar:
+There are 4 ways to configure the toolbar:
 
 ## Pre-Configure Toolbar Options
 
@@ -24,6 +24,16 @@ You can also set your own options like this:
 ~~~
 
 See [Quill toolbar docs](https://quilljs.com/docs/modules/toolbar/) for more details.
+
+## Disable Toolbar
+
+Pass `false` to the `toolbar` prop to disable the toolbar module:
+
+~~~ vue
+<template>
+  <QuillEditor :toolbar="false" .../>
+</template>
+~~~
 
 ## Custom Toolbar Container
 

--- a/examples/vue-quill/src/example-catalog.test.ts
+++ b/examples/vue-quill/src/example-catalog.test.ts
@@ -41,7 +41,7 @@ describe('Vue Quill example catalog', () => {
   it('documents supported toolbar and theme variations', () => {
     assert.deepEqual(
       toolbarExamples.map((toolbar) => toolbar.id),
-      ['minimal', 'array', 'custom-container'],
+      ['minimal', 'array', 'custom-container', 'disabled'],
     )
     assert.deepEqual(
       themeExamples.map((theme) => theme.value),

--- a/examples/vue-quill/src/example-catalog.ts
+++ b/examples/vue-quill/src/example-catalog.ts
@@ -10,7 +10,7 @@ export type ExampleSectionId =
 
 export type ThemeValue = 'snow' | 'bubble' | ''
 
-export type ToolbarValue = string | unknown[]
+export type ToolbarValue = string | unknown[] | false
 
 export type ExampleSection = {
   id: ExampleSectionId
@@ -20,7 +20,7 @@ export type ExampleSection = {
 }
 
 export type ToolbarExample = {
-  id: 'minimal' | 'array' | 'custom-container'
+  id: 'minimal' | 'array' | 'custom-container' | 'disabled'
   label: string
   description: string
   toolbar: ToolbarValue
@@ -66,7 +66,7 @@ export const exampleSections: ExampleSection[] = [
     id: 'toolbars',
     title: 'Toolbar customization',
     description:
-      'Switch between a built-in preset, an inline toolbar array, and a custom slot toolbar.',
+      'Switch between a built-in preset, an inline toolbar array, a custom slot toolbar, and no toolbar.',
     coverage: ['configuration variations', 'toolbar customization'],
   },
   {
@@ -129,6 +129,12 @@ export const toolbarExamples: ToolbarExample[] = [
     label: 'Custom container',
     description: 'Provides toolbar markup through the toolbar slot.',
     toolbar: '#article-toolbar',
+  },
+  {
+    id: 'disabled',
+    label: 'No toolbar',
+    description: 'Passes false to disable the toolbar module.',
+    toolbar: false,
   },
 ]
 

--- a/packages/vue-quill/src/components/QuillEditor.test.ts
+++ b/packages/vue-quill/src/components/QuillEditor.test.ts
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { describe, it } from 'node:test'
+import ts from 'typescript'
+
+const sourceFile = ts.createSourceFile(
+  'QuillEditor.ts',
+  readFileSync(new URL('./QuillEditor.ts', import.meta.url), 'utf8'),
+  ts.ScriptTarget.Latest,
+  true,
+  ts.ScriptKind.TS,
+)
+
+const getPropertyName = (node: ts.PropertyName): string | undefined => {
+  if (ts.isIdentifier(node) || ts.isStringLiteral(node)) return node.text
+  return undefined
+}
+
+const findToolbarProp = (): ts.ObjectLiteralExpression => {
+  let toolbarProp: ts.ObjectLiteralExpression | undefined
+
+  const visit = (node: ts.Node) => {
+    if (
+      ts.isPropertyAssignment(node) &&
+      getPropertyName(node.name) === 'toolbar' &&
+      ts.isObjectLiteralExpression(node.initializer)
+    ) {
+      toolbarProp = node.initializer
+      return
+    }
+
+    ts.forEachChild(node, visit)
+  }
+
+  visit(sourceFile)
+
+  assert.ok(toolbarProp, 'toolbar prop should be defined')
+  return toolbarProp
+}
+
+describe('QuillEditor toolbar prop', () => {
+  it('accepts false to disable the toolbar', () => {
+    const typeProperty = findToolbarProp().properties.find(
+      (property): property is ts.PropertyAssignment =>
+        ts.isPropertyAssignment(property) &&
+        getPropertyName(property.name) === 'type',
+    )
+
+    assert.ok(typeProperty, 'toolbar prop should define runtime types')
+    assert.match(
+      typeProperty.initializer.getText(sourceFile),
+      /\bBoolean\b/,
+      'toolbar prop runtime types should include Boolean',
+    )
+  })
+
+  it('keeps the absent toolbar prop distinct from false', () => {
+    const defaultProperty = findToolbarProp().properties.find(
+      (property): property is ts.PropertyAssignment =>
+        ts.isPropertyAssignment(property) &&
+        getPropertyName(property.name) === 'default',
+    )
+
+    assert.ok(defaultProperty, 'toolbar prop should define an explicit default')
+    assert.equal(
+      defaultProperty.initializer.getText(sourceFile),
+      'undefined',
+      'toolbar prop should not cast an absent prop to false',
+    )
+  })
+})

--- a/packages/vue-quill/src/components/QuillEditor.ts
+++ b/packages/vue-quill/src/components/QuillEditor.ts
@@ -18,6 +18,7 @@ import { loadQuill, type QuillConstructor } from '../quill'
 export type Module = { name: string; module: unknown; options?: object }
 
 type ContentPropType = string | Delta | undefined | null
+type ToolbarPropType = string | unknown[] | Record<string, unknown> | false
 type QuillWithImports = QuillConstructor & { imports?: Record<string, unknown> }
 type ToolbarModule = { container?: HTMLElement | null }
 type TextChangeHandler = (
@@ -80,9 +81,11 @@ export const QuillEditor = defineComponent({
       },
     },
     toolbar: {
-      type: [String, Array, Object],
+      type: [String, Array, Object, Boolean] as PropType<ToolbarPropType>,
       required: false,
+      default: undefined,
       validator: (value: string | unknown) => {
+        if (typeof value === 'boolean') return value === false
         if (typeof value === 'string' && value !== '') {
           return value.charAt(0) === '#'
             ? true
@@ -192,7 +195,11 @@ export const QuillEditor = defineComponent({
       if (props.theme !== '') clientOptions.theme = props.theme
       if (props.readOnly) clientOptions.readOnly = props.readOnly
       if (props.placeholder) clientOptions.placeholder = props.placeholder
-      if (props.toolbar && props.toolbar !== '') {
+      if (props.toolbar === false) {
+        clientOptions.modules = {
+          toolbar: false,
+        }
+      } else if (props.toolbar && props.toolbar !== '') {
         clientOptions.modules = {
           toolbar: (() => {
             if (typeof props.toolbar === 'object') {


### PR DESCRIPTION
## Summary

Fixes https://github.com/vueup/vue-quill/issues/516.

This adds an explicit public way to disable the Quill toolbar with:

```vue
<QuillEditor :toolbar="false" />
```

## Root cause

The `toolbar` prop only accepted `String | Array | Object` at runtime. Users trying to pass `false` either received Vue prop warnings or reached for `modules`, which is the custom module registration prop and not the right surface for disabling Quill's toolbar.

## What changed

- Added `false` as a valid `toolbar` prop value.
- Composes `toolbar={false}` to `modules.toolbar = false` so Quill disables the toolbar module explicitly.
- Keeps `default: undefined` so an omitted `toolbar` prop does not get cast to `false` by Vue's Boolean prop handling.
- Added a regression test for the prop contract.
- Documented the disabled-toolbar usage in the API and toolbar guide.
- Added the no-toolbar mode to the example catalog.

## Validation

- `node --experimental-strip-types --test packages/vue-quill/src/components/QuillEditor.test.ts examples/vue-quill/src/example-catalog.test.ts`
- `npm run lint`
- `npx tsc --noEmit`
- `npm run build`
- `npm run assets:build -- vue-quill`
- `npm run docs:build`

Note: `docs:build` needs the CSS assets generated after `npm run build`, because the package build recreates `packages/vue-quill/dist` without the CSS assets.
