### PR TITLE
[codex] fix: support full module registration paths

### DIFF
--- a/docs/content/api/index.md
+++ b/docs/content/api/index.md
@@ -58,7 +58,7 @@
 ## modules
 - **Type:** `Object | Object[]`
 
-  Options to register modules, see [Modules](../guide/modules.md) section for more details.
+  Options to register Quill modules, formats, and blots. Module names can be passed as shorthand names like `imageUploader` or as full Quill registration paths like `modules/mention` and `blots/mention`. See [Modules](../guide/modules.md) section for more details.
 
 ## options
 - **Type:** `Object`

--- a/docs/content/guide/modules.md
+++ b/docs/content/guide/modules.md
@@ -97,6 +97,33 @@ export default defineComponent({
 
 See [Quill modules docs](https://quilljs.com/docs/modules/) for more details.
 
+## Registering Formats And Blots
+
+Use a shorthand name for ordinary modules, or pass a full Quill registration path when a package exposes formats or blots that must be registered before the module.
+
+~~~ js
+import { Mention, MentionBlot } from 'quill-mention'
+
+const modules = [
+  {
+    name: 'blots/mention',
+    module: MentionBlot,
+  },
+  {
+    name: 'modules/mention',
+    module: Mention,
+    options: {
+      mentionDenotationChars: ['@'],
+      source: (searchTerm, renderList) => {
+        renderList([], searchTerm)
+      },
+    },
+  },
+]
+~~~
+
+`modules/mention` is registered as a Quill module and its `options` are passed to Quill as `modules.mention`. `blots/mention` is registered as a Quill blot and is not added to the module options.
+
 ## Quill Modules
 
 - [quill-autoformat](https://github.com/weavy/quill-autoformat) - Module for transforming text including mentions, links and hashtags

--- a/docs/content/guide/modules.md
+++ b/docs/content/guide/modules.md
@@ -15,7 +15,7 @@ yarn add @enzedonline/quill-blot-formatter2
 
 **Usage:**
 
-~~~ vue
+```vue
 <template>
   <QuillEditor :modules="modules" toolbar="full" />
 </template>
@@ -41,7 +41,7 @@ export default defineComponent({
   },
 })
 </script>
-~~~
+```
 ## Example using quill-image-uploader
 In this example I am gonna use [quill-image-uploader](https://github.com/NoelOConnell/quill-image-uploader), A module for Quill rich text editor to allow images to be uploaded to a server instead of being base64 encoded.
 
@@ -52,7 +52,7 @@ npm install quill-image-uploader --save
 ```
 **Usage:**
 
-~~~ vue
+```vue
 <template>
   <QuillEditor :modules="modules" toolbar="full" />
 </template>
@@ -93,7 +93,7 @@ export default defineComponent({
   }
 })
 </script>
-~~~
+```
 
 See [Quill modules docs](https://quilljs.com/docs/modules/) for more details.
 
@@ -101,7 +101,7 @@ See [Quill modules docs](https://quilljs.com/docs/modules/) for more details.
 
 Use a shorthand name for ordinary modules, or pass a full Quill registration path when a package exposes formats or blots that must be registered before the module.
 
-~~~ js
+```js
 import { Mention, MentionBlot } from 'quill-mention'
 
 const modules = [
@@ -120,17 +120,17 @@ const modules = [
     },
   },
 ]
-~~~
+```
 
 `modules/mention` is registered as a Quill module and its `options` are passed to Quill as `modules.mention`. `blots/mention` is registered as a Quill blot and is not added to the module options.
 
 If you use Quill's `formats` option, include the mention blot name so Quill allows mention embeds in the editor contents:
 
-~~~ js
+```js
 const options = {
   formats: ['bold', 'italic', 'mention'],
 }
-~~~
+```
 
 ## Quill Modules
 

--- a/docs/content/guide/modules.md
+++ b/docs/content/guide/modules.md
@@ -124,6 +124,14 @@ const modules = [
 
 `modules/mention` is registered as a Quill module and its `options` are passed to Quill as `modules.mention`. `blots/mention` is registered as a Quill blot and is not added to the module options.
 
+If you use Quill's `formats` option, include the mention blot name so Quill allows mention embeds in the editor contents:
+
+~~~ js
+const options = {
+  formats: ['bold', 'italic', 'mention'],
+}
+~~~
+
 ## Quill Modules
 
 - [quill-autoformat](https://github.com/weavy/quill-autoformat) - Module for transforming text including mentions, links and hashtags

--- a/packages/vue-quill/src/components/QuillEditor.test.ts
+++ b/packages/vue-quill/src/components/QuillEditor.test.ts
@@ -69,3 +69,35 @@ describe('QuillEditor toolbar prop', () => {
     )
   })
 })
+
+describe('QuillEditor module registration', () => {
+  it('passes the composed Quill registry to module registration', () => {
+    const registerModuleCalls: ts.CallExpression[] = []
+
+    const visit = (node: ts.Node) => {
+      if (
+        ts.isCallExpression(node) &&
+        ts.isIdentifier(node.expression) &&
+        node.expression.text === 'registerModule'
+      ) {
+        registerModuleCalls.push(node)
+      }
+
+      ts.forEachChild(node, visit)
+    }
+
+    visit(sourceFile)
+
+    assert.ok(
+      registerModuleCalls.length > 0,
+      'QuillEditor should register modules through registerModule',
+    )
+    for (const call of registerModuleCalls) {
+      assert.equal(
+        call.arguments[2]?.getText(sourceFile),
+        'options.registry',
+        'registerModule should receive the composed Quill registry',
+      )
+    }
+  })
+})

--- a/packages/vue-quill/src/components/QuillEditor.ts
+++ b/packages/vue-quill/src/components/QuillEditor.ts
@@ -13,17 +13,13 @@ import {
 import type { PropType } from 'vue'
 import { toolbarOptions } from './options'
 import type { ToolbarOptions } from './options'
-import { loadQuill, type QuillConstructor } from '../quill'
-import {
-  getModuleOptions,
-  getModuleRegistrationName,
-} from './moduleRegistration'
+import { loadQuill } from '../quill'
+import { getModuleOptions, registerModule } from './moduleRegistration'
 
 export type Module = { name: string; module: unknown; options?: object }
 
 type ContentPropType = string | Delta | undefined | null
 type ToolbarPropType = string | unknown[] | Record<string, unknown> | false
-type QuillWithImports = QuillConstructor & { imports?: Record<string, unknown> }
 type ToolbarModule = { container?: HTMLElement | null }
 type TextChangeHandler = (
   delta: Delta,
@@ -136,19 +132,6 @@ export const QuillEditor = defineComponent({
     let options: QuillOptions
     const editor = ref<HTMLElement>()
 
-    // Register Module if not already registered
-    const registerModule = (
-      Quill: QuillConstructor,
-      moduleName: string,
-      module: unknown,
-    ) => {
-      const quillImports = (Quill as QuillWithImports).imports
-      if (quillImports && moduleName in quillImports) {
-        return
-      }
-      Quill.register(moduleName, module)
-    }
-
     // Initialize Quill
     const initialize = async () => {
       if (!editor.value) return
@@ -161,18 +144,10 @@ export const QuillEditor = defineComponent({
       if (props.modules) {
         if (Array.isArray(props.modules)) {
           for (const module of props.modules) {
-            registerModule(
-              Quill,
-              getModuleRegistrationName(module.name),
-              module.module,
-            )
+            registerModule(Quill, module, options.registry)
           }
         } else {
-          registerModule(
-            Quill,
-            getModuleRegistrationName(props.modules.name),
-            props.modules.module,
-          )
+          registerModule(Quill, props.modules, options.registry)
         }
       }
       // Create new Quill instance

--- a/packages/vue-quill/src/components/QuillEditor.ts
+++ b/packages/vue-quill/src/components/QuillEditor.ts
@@ -15,7 +15,7 @@ import { toolbarOptions } from './options'
 import type { ToolbarOptions } from './options'
 import { loadQuill, type QuillConstructor } from '../quill'
 import {
-  getModuleOptionName,
+  getModuleOptions,
   getModuleRegistrationName,
 } from './moduleRegistration'
 
@@ -223,25 +223,14 @@ export const QuillEditor = defineComponent({
         }
       }
       if (props.modules) {
-        const modules = (() => {
-          const modulesOption: { [key: string]: unknown } = {}
-          if (Array.isArray(props.modules)) {
-            for (const module of props.modules) {
-              const optionName = getModuleOptionName(module.name)
-              if (optionName) modulesOption[optionName] = module.options ?? {}
-            }
-          } else {
-            const optionName = getModuleOptionName(props.modules.name)
-            if (optionName)
-              modulesOption[optionName] = props.modules.options ?? {}
-          }
-          return modulesOption
-        })()
-        clientOptions.modules = Object.assign(
-          {},
-          clientOptions.modules,
-          modules,
-        )
+        const modules = getModuleOptions(props.modules)
+        if (modules) {
+          clientOptions.modules = Object.assign(
+            {},
+            clientOptions.modules,
+            modules,
+          )
+        }
       }
       return Object.assign(
         {},

--- a/packages/vue-quill/src/components/QuillEditor.ts
+++ b/packages/vue-quill/src/components/QuillEditor.ts
@@ -14,6 +14,10 @@ import type { PropType } from 'vue'
 import { toolbarOptions } from './options'
 import type { ToolbarOptions } from './options'
 import { loadQuill, type QuillConstructor } from '../quill'
+import {
+  getModuleOptionName,
+  getModuleRegistrationName,
+} from './moduleRegistration'
 
 export type Module = { name: string; module: unknown; options?: object }
 
@@ -157,12 +161,16 @@ export const QuillEditor = defineComponent({
       if (props.modules) {
         if (Array.isArray(props.modules)) {
           for (const module of props.modules) {
-            registerModule(Quill, `modules/${module.name}`, module.module)
+            registerModule(
+              Quill,
+              getModuleRegistrationName(module.name),
+              module.module,
+            )
           }
         } else {
           registerModule(
             Quill,
-            `modules/${props.modules.name}`,
+            getModuleRegistrationName(props.modules.name),
             props.modules.module,
           )
         }
@@ -219,10 +227,13 @@ export const QuillEditor = defineComponent({
           const modulesOption: { [key: string]: unknown } = {}
           if (Array.isArray(props.modules)) {
             for (const module of props.modules) {
-              modulesOption[module.name] = module.options ?? {}
+              const optionName = getModuleOptionName(module.name)
+              if (optionName) modulesOption[optionName] = module.options ?? {}
             }
           } else {
-            modulesOption[props.modules.name] = props.modules.options ?? {}
+            const optionName = getModuleOptionName(props.modules.name)
+            if (optionName)
+              modulesOption[optionName] = props.modules.options ?? {}
           }
           return modulesOption
         })()

--- a/packages/vue-quill/src/components/moduleRegistration.test.mjs
+++ b/packages/vue-quill/src/components/moduleRegistration.test.mjs
@@ -14,12 +14,42 @@ describe('module registration names', () => {
       'modules/mention',
     )
     assert.equal(getModuleRegistrationName('blots/mention'), 'blots/mention')
+    assert.equal(
+      getModuleRegistrationName('formats/mention'),
+      'formats/mention',
+    )
+    assert.equal(
+      getModuleRegistrationName('attributors/class/mention'),
+      'attributors/class/mention',
+    )
+    assert.equal(getModuleRegistrationName('themes/custom'), 'themes/custom')
+    assert.equal(getModuleRegistrationName('ui/icons'), 'ui/icons')
   })
 
   it('only adds Quill module registrations to options.modules', () => {
     assert.equal(getModuleOptionName('mention'), 'mention')
     assert.equal(getModuleOptionName('modules/mention'), 'mention')
     assert.equal(getModuleOptionName('blots/mention'), undefined)
+  })
+
+  it('keeps slash-containing shorthand names as modules', () => {
+    const options = { source: () => [] }
+
+    assert.equal(
+      getModuleRegistrationName('@scope/mention'),
+      'modules/@scope/mention',
+    )
+    assert.equal(getModuleOptionName('@scope/mention'), '@scope/mention')
+    assert.deepEqual(
+      getModuleOptions({
+        name: '@scope/mention',
+        module: {},
+        options,
+      }),
+      {
+        '@scope/mention': options,
+      },
+    )
   })
 
   it('does not create an empty modules option for non-module registrations', () => {

--- a/packages/vue-quill/src/components/moduleRegistration.test.mjs
+++ b/packages/vue-quill/src/components/moduleRegistration.test.mjs
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 import {
+  getModuleOptions,
   getModuleOptionName,
   getModuleRegistrationName,
 } from './moduleRegistration.ts'
@@ -19,5 +20,36 @@ describe('module registration names', () => {
     assert.equal(getModuleOptionName('mention'), 'mention')
     assert.equal(getModuleOptionName('modules/mention'), 'mention')
     assert.equal(getModuleOptionName('blots/mention'), undefined)
+  })
+
+  it('does not create an empty modules option for non-module registrations', () => {
+    assert.equal(
+      getModuleOptions({
+        name: 'blots/mention',
+        module: {},
+      }),
+      undefined,
+    )
+  })
+
+  it('composes options only for module registrations', () => {
+    const mentionOptions = { allowedChars: /^[A-Za-z\\s]*$/ }
+
+    assert.deepEqual(
+      getModuleOptions([
+        {
+          name: 'blots/mention',
+          module: {},
+        },
+        {
+          name: 'modules/mention',
+          module: {},
+          options: mentionOptions,
+        },
+      ]),
+      {
+        mention: mentionOptions,
+      },
+    )
   })
 })

--- a/packages/vue-quill/src/components/moduleRegistration.test.mjs
+++ b/packages/vue-quill/src/components/moduleRegistration.test.mjs
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import {
+  getModuleOptionName,
+  getModuleRegistrationName,
+} from './moduleRegistration.ts'
+
+describe('module registration names', () => {
+  it('keeps full Quill registration paths intact', () => {
+    assert.equal(getModuleRegistrationName('mention'), 'modules/mention')
+    assert.equal(
+      getModuleRegistrationName('modules/mention'),
+      'modules/mention',
+    )
+    assert.equal(getModuleRegistrationName('blots/mention'), 'blots/mention')
+  })
+
+  it('only adds Quill module registrations to options.modules', () => {
+    assert.equal(getModuleOptionName('mention'), 'mention')
+    assert.equal(getModuleOptionName('modules/mention'), 'mention')
+    assert.equal(getModuleOptionName('blots/mention'), undefined)
+  })
+})

--- a/packages/vue-quill/src/components/moduleRegistration.test.mjs
+++ b/packages/vue-quill/src/components/moduleRegistration.test.mjs
@@ -140,6 +140,29 @@ describe('module registration names', () => {
     assert.deepEqual(registryRegistrations, [mentionBlot])
   })
 
+  it('registers attributors with a custom Quill registry', () => {
+    const mentionAttributor = {}
+    const registryRegistrations = []
+
+    registerModule(
+      {
+        imports: {},
+        register: () => {},
+      },
+      {
+        name: 'attributors/class/mention',
+        module: mentionAttributor,
+      },
+      {
+        register: (module) => {
+          registryRegistrations.push(module)
+        },
+      },
+    )
+
+    assert.deepEqual(registryRegistrations, [mentionAttributor])
+  })
+
   it('does not register Quill modules with a custom Quill registry', () => {
     const mentionModule = {}
     const registryRegistrations = []

--- a/packages/vue-quill/src/components/moduleRegistration.test.mjs
+++ b/packages/vue-quill/src/components/moduleRegistration.test.mjs
@@ -4,6 +4,7 @@ import {
   getModuleOptions,
   getModuleOptionName,
   getModuleRegistrationName,
+  registerModule,
 } from './moduleRegistration.ts'
 
 describe('module registration names', () => {
@@ -81,5 +82,84 @@ describe('module registration names', () => {
         mention: mentionOptions,
       },
     )
+  })
+
+  it('registers blots with a custom Quill registry', () => {
+    const mentionBlot = {}
+    const globalRegistrations = []
+    const registryRegistrations = []
+
+    registerModule(
+      {
+        imports: {},
+        register: (name, module) => {
+          globalRegistrations.push([name, module])
+        },
+      },
+      {
+        name: 'blots/mention',
+        module: mentionBlot,
+      },
+      {
+        register: (module) => {
+          registryRegistrations.push(module)
+        },
+      },
+    )
+
+    assert.deepEqual(globalRegistrations, [['blots/mention', mentionBlot]])
+    assert.deepEqual(registryRegistrations, [mentionBlot])
+  })
+
+  it('registers already imported blots with a custom Quill registry', () => {
+    const mentionBlot = {}
+    const globalRegistrations = []
+    const registryRegistrations = []
+
+    registerModule(
+      {
+        imports: {
+          'blots/mention': mentionBlot,
+        },
+        register: (name, module) => {
+          globalRegistrations.push([name, module])
+        },
+      },
+      {
+        name: 'blots/mention',
+        module: mentionBlot,
+      },
+      {
+        register: (module) => {
+          registryRegistrations.push(module)
+        },
+      },
+    )
+
+    assert.deepEqual(globalRegistrations, [])
+    assert.deepEqual(registryRegistrations, [mentionBlot])
+  })
+
+  it('does not register Quill modules with a custom Quill registry', () => {
+    const mentionModule = {}
+    const registryRegistrations = []
+
+    registerModule(
+      {
+        imports: {},
+        register: () => {},
+      },
+      {
+        name: 'modules/mention',
+        module: mentionModule,
+      },
+      {
+        register: (module) => {
+          registryRegistrations.push(module)
+        },
+      },
+    )
+
+    assert.deepEqual(registryRegistrations, [])
   })
 })

--- a/packages/vue-quill/src/components/moduleRegistration.ts
+++ b/packages/vue-quill/src/components/moduleRegistration.ts
@@ -25,7 +25,18 @@ export const getModuleOptionName = (name: string): string | undefined => {
     : undefined
 }
 
-type ModuleRegistration = { name: string; options?: object }
+type ModuleRegistration = { name: string; module: unknown; options?: object }
+type QuillRegistrationTarget = {
+  imports?: Record<string, unknown>
+  register: (name: string, module: unknown) => void
+}
+type QuillRegistry = { register: (...definitions: never[]) => unknown }
+const globalRegistryPathPrefixes = new Set(['blots', 'formats'])
+
+const usesParchmentRegistry = (name: string): boolean => {
+  const [prefix] = name.split('/')
+  return globalRegistryPathPrefixes.has(prefix)
+}
 
 export const getModuleOptions = (
   modules: ModuleRegistration | ModuleRegistration[],
@@ -39,4 +50,19 @@ export const getModuleOptions = (
   }
 
   return Object.keys(modulesOption).length > 0 ? modulesOption : undefined
+}
+
+export const registerModule = (
+  Quill: QuillRegistrationTarget,
+  module: ModuleRegistration,
+  registry?: QuillRegistry,
+) => {
+  const moduleName = getModuleRegistrationName(module.name)
+  const quillImports = Quill.imports
+  if (!quillImports || !(moduleName in quillImports)) {
+    Quill.register(moduleName, module.module)
+  }
+  if (registry && usesParchmentRegistry(moduleName)) {
+    registry.register(module.module as never)
+  }
 }

--- a/packages/vue-quill/src/components/moduleRegistration.ts
+++ b/packages/vue-quill/src/components/moduleRegistration.ts
@@ -1,5 +1,19 @@
+const quillRegistrationPathPrefixes = new Set([
+  'attributors',
+  'blots',
+  'formats',
+  'modules',
+  'themes',
+  'ui',
+])
+
+const isQuillRegistrationPath = (name: string): boolean => {
+  const [prefix] = name.split('/')
+  return quillRegistrationPathPrefixes.has(prefix)
+}
+
 export const getModuleRegistrationName = (name: string): string => {
-  return name.includes('/') ? name : `modules/${name}`
+  return isQuillRegistrationPath(name) ? name : `modules/${name}`
 }
 
 export const getModuleOptionName = (name: string): string | undefined => {

--- a/packages/vue-quill/src/components/moduleRegistration.ts
+++ b/packages/vue-quill/src/components/moduleRegistration.ts
@@ -31,7 +31,7 @@ type QuillRegistrationTarget = {
   register: (name: string, module: unknown) => void
 }
 type QuillRegistry = { register: (...definitions: never[]) => unknown }
-const globalRegistryPathPrefixes = new Set(['blots', 'formats'])
+const globalRegistryPathPrefixes = new Set(['attributors', 'blots', 'formats'])
 
 const usesParchmentRegistry = (name: string): boolean => {
   const [prefix] = name.split('/')

--- a/packages/vue-quill/src/components/moduleRegistration.ts
+++ b/packages/vue-quill/src/components/moduleRegistration.ts
@@ -1,0 +1,12 @@
+export const getModuleRegistrationName = (name: string): string => {
+  return name.includes('/') ? name : `modules/${name}`
+}
+
+export const getModuleOptionName = (name: string): string | undefined => {
+  const registrationName = getModuleRegistrationName(name)
+  const modulePrefix = 'modules/'
+
+  return registrationName.startsWith(modulePrefix)
+    ? registrationName.slice(modulePrefix.length)
+    : undefined
+}

--- a/packages/vue-quill/src/components/moduleRegistration.ts
+++ b/packages/vue-quill/src/components/moduleRegistration.ts
@@ -10,3 +10,19 @@ export const getModuleOptionName = (name: string): string | undefined => {
     ? registrationName.slice(modulePrefix.length)
     : undefined
 }
+
+type ModuleRegistration = { name: string; options?: object }
+
+export const getModuleOptions = (
+  modules: ModuleRegistration | ModuleRegistration[],
+): { [key: string]: object } | undefined => {
+  const modulesOption: { [key: string]: object } = {}
+  const registrations = Array.isArray(modules) ? modules : [modules]
+
+  for (const module of registrations) {
+    const optionName = getModuleOptionName(module.name)
+    if (optionName) modulesOption[optionName] = module.options ?? {}
+  }
+
+  return Object.keys(modulesOption).length > 0 ? modulesOption : undefined
+}


### PR DESCRIPTION
## Summary

Fixes https://github.com/vueup/vue-quill/issues/553.

This lets `modules` entries use full Quill registration paths, including packages that need to register formats or blots before registering a module:

```js
const modules = [
  { name: 'blots/mention', module: MentionBlot },
  { name: 'modules/mention', module: Mention, options: { /* ... */ } },
]
```

## Root cause

`QuillEditor` always prefixed `module.name` with `modules/` during registration. That kept shorthand names like `imageUploader` working, but corrupted already-qualified paths:

- `modules/mention` became `modules/modules/mention`
- `blots/mention` became `modules/blots/mention`

It also copied non-module registration names into `options.modules`, so a blot registration could be treated as a Quill module option.

## What changed

- Added module registration normalization helpers.
- Shorthand names still register as `modules/<name>` and keep their options under `modules.<name>`.
- Full `modules/<name>` paths are registered unchanged and options are passed under `modules.<name>`.
- Non-module paths such as `blots/mention` are registered unchanged and excluded from `options.modules`.
- Added regression coverage for path normalization.
- Documented full registration paths and a quill-mention example.

## Validation

- `node --experimental-strip-types --test packages/vue-quill/src/components/moduleRegistration.test.mjs packages/vue-quill/src/components/QuillEditor.test.ts examples/vue-quill/src/example-catalog.test.ts`
- `npm run lint`
- `npx tsc --noEmit`
- `npm run build -- vue-quill --assets --types`
- `npx ts-node scripts/verifyRelease.ts vue-quill`
- `npm run docs:build`

Notes: Node emits the existing `MODULE_TYPELESS_PACKAGE_JSON` warning for strip-types tests. API Extractor emits its existing warning about bundled TypeScript being older than the project TypeScript, but type rollup completed successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified `modules` prop to document shorthand and full registration paths for modules, formats, and blots; added examples for registering formats/blots with module options.

* **Tests**
  * Added comprehensive tests covering module/format/blot registration and option composition.

* **Refactor**
  * Improved module registration and option resolution to make shorthand and full-path registrations behave consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->