### PR TITLE
Fix npm package README publishing

### DIFF
--- a/packages/vue-quill/README.md
+++ b/packages/vue-quill/README.md
@@ -1,0 +1,75 @@
+<p align="center">
+	<a href="https://vueup.github.io/vue-quill/" target="_blank" rel="noopener noreferrer">
+		<img height="120" src="https://vueup.github.io/vue-quill/quill.svg" alt="Vue + Quill logo">
+	</a>
+</p>
+<h1 align="center">VueQuill</h1>
+<h3 align="center">
+	Rich Text Editor Component for Vue 3.
+</h3>
+<p align="center">
+	<a href="https://www.npmjs.com/package/@vueup/vue-quill" title="Version" target="_blank" rel="noopener noreferrer">
+		<img alt="npm (tag)" src="https://img.shields.io/npm/v/@vueup/vue-quill">
+	</a>
+	<a href="https://www.npmjs.com/package/@vueup/vue-quill" title="License" target="_blank" rel="noopener noreferrer">
+		<img src="https://img.shields.io/npm/l/@vueup/vue-quill" alt="License">
+	</a>
+	<a href="https://github.com/vueup/vue-quill/actions" title="Checks" target="_blank" rel="noopener noreferrer">
+		<img alt="GitHub Workflow Status" src="https://img.shields.io/github/actions/workflow/status/vueup/vue-quill/release-vue-quill.yml?branch=master&logo=github">
+	</a>
+	<a href="https://github.com/vueup/vue-quill" title="Last commit" target="_blank" rel="noopener noreferrer">
+		<img src="https://img.shields.io/github/last-commit/vueup/vue-quill?logo=github" alt="Last commit">
+	</a>
+	<a href="https://github.com/vueup/vue-quill" title="Github Repo Stars" target="_blank" rel="noopener noreferrer">
+		<img src="https://img.shields.io/github/stars/vueup/vue-quill?style=social" alt="Github Repo Stars">
+	</a>
+</p>
+<p align="center">
+	<a href="https://vueup.github.io/vue-quill/#demo" title="VueQuill Demo" target="_blank" rel="noopener noreferrer">
+		<img src="https://user-images.githubusercontent.com/6185447/111898684-33761b00-8a5a-11eb-9458-372c0185f576.png" alt="VueQuill Editor">
+	</a>
+	<br>
+	<a href="https://vueup.github.io/vue-quill/#demo" title="Live Demo" target="_blank" rel="noopener noreferrer">👀 See a Live Demo</a>
+</p>
+
+## 🔎 Overview
+
+**VueQuill** is a **Component** for building rich text editors, powered by Vue 3 and Quill.
+
+- 💚 **Built With Vue 3:** More powerful and performant framework than ever before.
+- 🧙‍♂️ **Fully Typescript:** VueQuill source code is written entirely in TypeScript.
+- 🛠️ **Easy To Use:** Straightforward implementation through a simple API.
+
+## 📚 Documentation
+
+- **[📘 Guide](https://vueup.github.io/vue-quill/guide/)**
+	- [🚀 Introduction](https://vueup.github.io/vue-quill/guide/)
+	- [⚙️ Installation](https://vueup.github.io/vue-quill/guide/installation.html)
+	- [💡 Usage](https://vueup.github.io/vue-quill/guide/usage.html)
+	- [🎨 Themes](https://vueup.github.io/vue-quill/guide/themes.html)
+	- [🚥 Toolbar](https://vueup.github.io/vue-quill/guide/toolbar.html)
+	- [📦 Modules](https://vueup.github.io/vue-quill/guide/modules.html)
+	- [🛠️ Options](https://vueup.github.io/vue-quill/guide/options.html)
+	- [🖥️ Server-Side Rendering](https://vueup.github.io/vue-quill/guide/ssr.html)
+- **[🧰 APIs](https://vueup.github.io/vue-quill/api/)**
+	- [📌 Props](https://vueup.github.io/vue-quill/api/)
+	- [⚡ Events](https://vueup.github.io/vue-quill/api/events.html)
+	- [📢 Methods](https://vueup.github.io/vue-quill/api/methods.html)
+	- [🔌 Slots](https://vueup.github.io/vue-quill/api/slots.html)
+	- [↗️ Export](https://vueup.github.io/vue-quill/api/export.html)
+
+## ☑️ To do list
+
+- [x] Release `alpha` version
+- [x] Release `beta` version
+- [x] Stable `v1.0.0` release
+- [x] Enhance Typescript support with Vue 3
+- [ ] Update the Documentation with more examples and more information
+
+## 👏 Contributing
+
+Pull requests are welcome. For major changes, please create a [new discussion](https://github.com/vueup/vue-quill/discussions) first about what you would like to change.
+
+## 📝 License
+
+[MIT](https://choosealicense.com/licenses/mit/)

--- a/scripts/verifyRelease.ts
+++ b/scripts/verifyRelease.ts
@@ -23,6 +23,9 @@
 
   logger.header(target, 'VERIFY RELEASE')
 
+  const readmePath: string = path.resolve(pkgDir, 'README.md')
+  checkReadmeFile(`${target} readme`, readmePath)
+
   // verify package main entry (index.js)
   const mainEntryPath: string = path.resolve(pkgDir, pkg.main)
   checkBuildFile(`${target} main`, mainEntryPath)
@@ -79,6 +82,36 @@
           `✖  The file ${chalk.underline(buildPath)} file does not exist.`,
         )
         errors.push(`Missing file: ${buildPath}`)
+      }
+    } catch (err: any) {
+      logger.error(target, err)
+      errors.push(err.message || 'Unknown error')
+    }
+  }
+
+  function checkReadmeFile(target: string, readmePath: string) {
+    try {
+      if (!fs.existsSync(readmePath)) {
+        logger.error(
+          target,
+          `✖  The file ${chalk.underline(readmePath)} file does not exist.`,
+        )
+        errors.push(`Missing README: ${readmePath}`)
+        return
+      }
+
+      const readme: string = fs.readFileSync(readmePath, 'utf8').trim()
+      if (readme.length) {
+        logger.success(
+          target,
+          `✔  The file ${chalk.underline(readmePath)} exists and is not empty.`,
+        )
+      } else {
+        logger.error(
+          target,
+          `✖  The file ${chalk.underline(readmePath)} file is empty.`,
+        )
+        errors.push(`Empty README: ${readmePath}`)
       }
     } catch (err: any) {
       logger.error(target, err)


### PR DESCRIPTION
Fixes the npm package page showing that `@vueup/vue-quill` has no README by adding README content to the package directory that is published to npm.

Summary:
- Populate `packages/vue-quill/README.md`, which is the README included in the npm tarball.
- Add a release verification check that fails when a published package README is missing or empty.

Verification:
- `cd packages/vue-quill && npm pack --dry-run` shows `3.8kB README.md` in the tarball.
- `npx ts-node scripts/verifyRelease.ts vue-quill` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive README for the Vue Quill package with project overview, documentation links, and contribution guidelines.

* **Chores**
  * Updated release verification process to validate README files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->